### PR TITLE
Fixed import conflict from deprecated biotite function needed by ESM

### DIFF
--- a/stab_ESM_IF.ipynb
+++ b/stab_ESM_IF.ipynb
@@ -1,23 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "gpuType": "T4"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "AcjxZ9mXikrK"
+      },
       "source": [
         "# <b><font color='#009e74'>Absolute folding stabiity prediction via generative models</font></b>\n",
         "Colaboratory implementation of : **Cagiada M., Ovchinnikov S. & Lindorff-Larsen K.** - [Predicting absolute protein folding stability using generative models\n",
@@ -31,13 +18,13 @@
         "\n",
         "where $\\mathscr{L}_i^{WT}$ is the amino acid likelihood extracted from ESM-IF for the wild-type amino acid at position i, to evaluate the absolute stability ($\\Delta G_{f-u}$) for a specific protein folding.\n",
         "\n"
-      ],
-      "metadata": {
-        "id": "AcjxZ9mXikrK"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "a4dANSUAinaS"
+      },
       "source": [
         "Additional notes:\n",
         "\n",
@@ -60,10 +47,7 @@
         "\n",
         "- An **alternative sequence** can be used in the input instead of the sequence extracted from the PDB file, **HOWEVER** it must be the same length as the original sequence.\n",
         "****"
-      ],
-      "metadata": {
-        "id": "a4dANSUAinaS"
-      }
+      ]
     },
     {
       "cell_type": "code",
@@ -117,7 +101,7 @@
         "    os.system(f\"pip install torch-spline-conv -f https://data.pyg.org/whl/torch-{TORCH}+{CUDA}.html\")\n",
         "    os.system(f\"pip install torch-geometric\")\n",
         "    os.system(f\"pip install biopython\")\n",
-        "    os.system(f\"pip install biotite\")\n",
+        "    os.system(f\"pip install biotite==0.41\")\n",
         "\n",
         "    print(\"installing esmfold...\")\n",
         "    # install esmfold\n",
@@ -150,6 +134,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "lWXN38psLY3u"
+      },
+      "outputs": [],
       "source": [
         "#@title <b><font color='#f0e422'>PRELIMINARY OPERATIONS:</font> Load EXTRA functions\n",
         "#@markdown Run the cell to load the required functions\n",
@@ -201,16 +191,16 @@
         "\n",
         "    score = token_probs[0,idx, mt_encoded]\n",
         "    return score.item()"
-      ],
-      "metadata": {
-        "id": "lWXN38psLY3u",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "fbmpNhrvbKil"
+      },
+      "outputs": [],
       "source": [
         "#@title <b><font color='#56b4e9'> DATA UPLOADING</font>\n",
         "#@markdown Fill in the fields and run the cell to set up the job name, import the structure, select the chain and upload an alternative sequence (not mandatory).\n",
@@ -264,16 +254,16 @@
         "\n",
         "print('... Target sequence:', sequence_structure)\n",
         "#@markdown ****"
-      ],
-      "metadata": {
-        "id": "fbmpNhrvbKil",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "ocOnty1TP9Ec"
+      },
+      "outputs": [],
       "source": [
         "#@title <b><font color='#56b4e9'> MODEL RUN</font>\n",
         "#@markdown Run this cell to evaluate the ΔG for the selected structure and sequence\n",
@@ -303,31 +293,28 @@
         "  os.rename(f\"inputs/query_protein.pdb\",f\"outputs/{output_name_pdb}\")\n",
         "except:\n",
         "  print('!!!! Data not saved, please re-upload the structure by running the uploading cell')\n"
-      ],
-      "metadata": {
-        "id": "ocOnty1TP9Ec",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "HdIPxqSE6zWi"
+      },
+      "outputs": [],
       "source": [
         "#@title <b><font color='#56b4e9'>DOWNLOAD RESULTS </font></b>\n",
         "#@markdown **N.B:** This will download **ALL** the predictions produced during the current session as zip file\n",
         "os.system( \"zip -r {} {}\".format( f\"dG_runs.zip\" , f\"outputs\" ) )\n",
         "files.download(f\"dG_runs.zip\")\n"
-      ],
-      "metadata": {
-        "id": "HdIPxqSE6zWi",
-        "cellView": "form"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "0NULd4ycW4dw"
+      },
       "source": [
         "<b><font color='#56b4e9'>EXTRA </font></b>\n",
         "\n",
@@ -396,10 +383,23 @@
         "citation here\n",
         "\n",
         "```\n"
-      ],
-      "metadata": {
-        "id": "0NULd4ycW4dw"
-      }
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "gpuType": "T4",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
Current version of Colab notebook `stab_ESM_IF.ipynb` crashes during the first import step:

`installing libs...
installing esmfold...
downloading params...
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<timed exec> in <module>

[/usr/local/lib/python3.10/dist-packages/esm/inverse_folding/__init__.py](https://r2mf5k9sfye-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab_20240910-060204_RC00_672911210#) in <module>
      4 # LICENSE file in the root directory of this source tree.
      5 
----> 6 from . import gvp_transformer
      7 from . import util
      8 from . import multichain_util

2 frames
[/usr/local/lib/python3.10/dist-packages/esm/inverse_folding/util.py](https://r2mf5k9sfye-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab_20240910-060204_RC00_672911210#) in <module>
     10 from biotite.structure.io import pdbx, pdb
     11 from biotite.structure.residues import get_residues
---> 12 from biotite.structure import filter_backbone
     13 from biotite.structure import get_chains
     14 from biotite.sequence import ProteinSequence

ImportError: cannot import name 'filter_backbone' from 'biotite.structure' (/usr/local/lib/python3.10/dist-packages/biotite/structure/__init__.py)`


Looking at the Biotite API, this function was deprecated with the 1.0 (current) release. To fix this, the pip install command for biotite needs to be changed to explicitly request the old version:

`os.system(f"pip install biotite==0.41")`

I have tested this on 10x input structures and it now seems to work as intended. Thanks for making this project open source and user-friendly!

